### PR TITLE
Ability to inject environment variables into the config file.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,28 @@
 //! See the integration tests (in the `tests/` directory) for sample use cases and more complex
 //! examples.
 //!
+//!# Environment variables
+//!
+//! The crate has an ability to inject environment variables into the configuration file. That
+//! becomes possible using special symtax:  
+//!
+//!  * $"SOME_ENV_VAR_NAME"::bool for `ScalarValue::Boolean`  
+//!  * $"SOME_ENV_VAR_NAME"::str for `ScalarValue::Str`  
+//!  * $"SOME_ENV_VAR_NAME"::i32 for `ScalarValue::Integer32`  
+//!  * $"SOME_ENV_VAR_NAME"::i64 for `ScalarValue::Integer64`  
+//!  * $"SOME_ENV_VAR_NAME"::f32 for `ScalarValue::Floating32`  
+//!  * $"SOME_ENV_VAR_NAME"::f64 for `ScalarValue::Floating64`  
+//!
+//!
+//! **Example**:
+//!
+//! ```ignore
+//! log = {
+//!       // Inject (use) the value of the environment variable LOG_LEVEL
+//!       level = $"LOG_LEVEL"::str;
+//! }
+//! ```
+//!
 //!# Grammar
 //!
 //! This section describes the configuration input format. The starting rule is `conf`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@
 //!# Environment variables
 //!
 //! The crate has an ability to inject environment variables into the configuration file. That
-//! becomes possible using special symtax:  
+//! becomes possible using special syntax:  
 //!
 //!  * $"SOME_ENV_VAR_NAME"::bool for `ScalarValue::Boolean`  
 //!  * $"SOME_ENV_VAR_NAME"::str for `ScalarValue::Str`  

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,17 +105,25 @@
 //! The crate has an ability to inject environment variables into the configuration file. That
 //! becomes possible using special syntax:  
 //!
-//!  * $"SOME_ENV_VAR_NAME"::bool for `ScalarValue::Boolean`  
-//!  * $"SOME_ENV_VAR_NAME"::str for `ScalarValue::Str`  
-//!  * $"SOME_ENV_VAR_NAME"::i32 for `ScalarValue::Integer32`  
-//!  * $"SOME_ENV_VAR_NAME"::i64 for `ScalarValue::Integer64`  
-//!  * $"SOME_ENV_VAR_NAME"::f32 for `ScalarValue::Floating32`  
-//!  * $"SOME_ENV_VAR_NAME"::f64 for `ScalarValue::Floating64`  
+//!  * `$"SOME_ENV_VAR_NAME"::str` to inject the environment variables `SOME_ENV_VAR_NAME` as the string value.
+//!    No additiocal changes are made ot the value.
+//!  * `$"SOME_ENV_VAR_NAME"::bool` to inject the environment variables `SOME_ENV_VAR_NAME` as the boolean value.
+//!    The value `true` or `yes` or `on` or `1` are converted into `true` otherwise into `false`.  
+//!  * `$"SOME_ENV_VAR_NAME"::int` to inject the environment variables `SOME_ENV_VAR_NAME` as the integer value.
+//!    The successfully parsed value is injected as `i32` or `i64`, depending on the format, otherwise `0i32` is injected.  
+//!  * `$"SOME_ENV_VAR_NAME"::flt` to inject the environment variables `SOME_ENV_VAR_NAME` as the floating value.
+//!    The successfully parsed value is injected as `f32` or `f64`, depending on the format, otherwise `0f32` is injected.  
 //!
 //!
 //! **Example**:
 //!
 //! ```ignore
+//! #!/bin/sh
+//! export LOG_LEVEL=debug
+//! ```
+//! 
+//! ```ignore
+//! // Configuration file
 //! log = {
 //!       // Inject (use) the value of the environment variable LOG_LEVEL
 //!       level = $"LOG_LEVEL"::str;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3569,15 +3569,24 @@ mod test {
 
         // Test float
         let input = &b"$\"TEST_FLT32\"::flt;\n"[..];
-        let res = flt_scalar_value(input);
-        assert_eq!(res, Done(&b";\n"[..], ScalarValue::Floating32(3.1415f32)));
+        if let Done(_, ScalarValue::Floating32(value)) = flt_scalar_value(input) {
+          assert!(value > 3.1414 && value < 3.1416);
+        } else {
+          panic!("Failed to read env f32");
+        }
 
         let input = &b"$\"TEST_FLT64\"::flt;\n"[..];
-        let res = flt_scalar_value(input);
-        assert_eq!(res, Done(&b";\n"[..], ScalarValue::Floating64(-3.1415f64)));
+        if let Done(_, ScalarValue::Floating64(value)) = flt_scalar_value(input) {
+          assert!(value > -3.1416 && value < -3.1414);
+        } else {
+          panic!("Failed to read env f64");
+        }
 
         let input = &b"$\"TEST_FLT_NOT_FOUND\"::flt;\n"[..];
-        let res = flt_scalar_value(input);
-        assert_eq!(res, Done(&b";\n"[..], ScalarValue::Floating32(0f32)));
+        if let Done(_, ScalarValue::Floating32(value)) = flt_scalar_value(input) {
+          assert!(value > -0.0001 && value < 0.0001);
+        } else {
+          panic!("Failed to read fake env float");
+        }
     }
 }


### PR DESCRIPTION
Hello,

I added some parsers which allow to inject environment variables into the config files. That requires additional syntax and tried to make it simple and Shell similar.

```
my_group = {
    some_bool = $"MY_BOOL"::bool;
    some_str = $"MY_STR"::str;
    some_int = $"MY_INT"::int;
    some_flt = $"MY_FLT"::flt;
};
```

It's good to have the host wide config parameter which can be set once and used everywhere, for example I use that to mark hardware I work on as development, production, etc.
