### PR TITLE
Update to nom 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/filipegoncalves/rust-config"
 readme = "README.md"
 
 [dependencies]
-nom = "~0.3.0"
+nom = "~1.0.0"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -153,9 +153,7 @@ use std::iter;
 
 use types::{SettingsList, Setting, Value, ScalarValue, ArrayValue, ListValue, Config};
 
-use nom::{alpha, alphanumeric, digit, multispace, not_line_ending};
-use nom::IResult;
-use nom::Err::Code;
+use nom::{alpha, alphanumeric, digit, multispace, not_line_ending, eof};
 use nom::IResult::*;
 
 pub type ParseError = u32;
@@ -561,14 +559,14 @@ named!(blanks,
 // NOTE: In some cases, this parser is combined with others that use `not_line_ending`
 //       However, `not_line_ending` won't match `\u{2028}` or `\u{2029}`
 named!(eol,
-       alt!(tag!("\r\n") | tag!("\n") | tag!("\u{2028}") | tag!("\u{2029}")));
+       alt!(tag!("\n") | tag!("\r\n") | tag!("\u{2028}") | tag!("\u{2029}")));
 
 // Auxiliary parser to ignore one-line comments
 named!(comment_one_line,
        chain!(
            alt!(tag!("//") | tag!("#")) ~
            not_line_ending? ~
-           alt!(eol | eof),
+           alt!(eof | eol),
            || { &b""[..] }));
 
 // Auxiliary parser to ignore block comments
@@ -577,15 +575,6 @@ named!(comment_block,
            tag!("/*") ~
            take_until_and_consume!(&b"*/"[..]),
            || { &b""[..] }));
-
-// This parser is successful only if the input is over
-fn eof(input:&[u8]) -> IResult<&[u8], &[u8]> {
-    if input.len() == 0 {
-        Done(input, input)
-    } else {
-        Error(Code(0))
-    }
-}
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ~~~ End of parsers section ~~~
@@ -742,8 +731,8 @@ mod test {
     use super::{value, array, group, list};
     use super::conf;
 
-    use nom::ErrorCode;
-    use nom::Err::{Code, Position};
+    use nom::ErrorKind;
+    use nom::Err::Position;
     use nom::IResult::*;
 
     use types::{Setting, SettingsList, Value, ScalarValue, Config};
@@ -788,14 +777,14 @@ mod test {
     fn setting_name_bad_num_prefix() {
         let a_setting = &b"12_xxx"[..];
         let res = setting_name(a_setting);
-        assert_eq!(res, Error(Position(ErrorCode::Alpha as u32, b"12_xxx")));
+        assert_eq!(res, Error(Position(ErrorKind::Alpha, &b"12_xxx"[..])));
     }
 
     #[test]
     fn setting_name_bad_symbol_prefix() {
         let a_setting = &b"__not_allowed"[..];
         let res = setting_name(a_setting);
-        assert_eq!(res, Error(Position(ErrorCode::Alpha as u32, b"__not_allowed")));
+        assert_eq!(res, Error(Position(ErrorKind::Alpha, &b"__not_allowed"[..])));
     }
 
     #[test]
@@ -935,14 +924,14 @@ mod test {
     fn bad_escape_sequence1() {
         let bad_escaped_seq = &b"\\q"[..];
         let res = escaped_seq(bad_escaped_seq);
-        assert_eq!(res, Error(Position(ErrorCode::Alt as u32, b"\\q")));
+        assert_eq!(res, Error(Position(ErrorKind::Alt, &b"\\q"[..])));
     }
 
     #[test]
     fn bad_escape_sequence2() {
         let bad_escape_seq = &b"aaa"[..];
         let res = escaped_seq(bad_escape_seq);
-        assert_eq!(res, Error(Position(ErrorCode::Alt as u32, b"aaa")));
+        assert_eq!(res, Error(Position(ErrorKind::Alt, &b"aaa"[..])));
     }
 
     #[test]
@@ -1055,7 +1044,7 @@ mod test {
     fn end_of_line1() {
         let input = &b"a test\n"[..];
         let res = eol(input);
-        assert_eq!(res, Error(Position(ErrorCode::Alt as u32, b"a test\n")));
+        assert_eq!(res, Error(Position(ErrorKind::Alt, &b"a test\n"[..])));
     }
 
     #[test]
@@ -1083,7 +1072,7 @@ mod test {
     fn one_line_comment_bad() {
         let input = &b"not a comment // see?"[..];
         let res = comment_one_line(input);
-        assert_eq!(res, Error(Position(ErrorCode::Alt as u32, b"not a comment // see?")));
+        assert_eq!(res, Error(Position(ErrorKind::Alt, &b"not a comment // see?"[..])));
     }
 
     #[test]
@@ -1118,7 +1107,7 @@ mod test {
     fn comment_blk_bad() {
         let input = &b"not a comment /* see?"[..];
         let res = comment_block(input);
-        assert_eq!(res, Error(Position(ErrorCode::Tag as u32, b"not a comment /* see?")));
+        assert_eq!(res, Error(Position(ErrorKind::Tag, &b"not a comment /* see?"[..])));
     }
 
     #[test]
@@ -1218,7 +1207,7 @@ mod test {
     fn flt_base_w_digits_before_dot() {
         let input = &b".4435"[..];
         let res = flt_base_w_digits_bef_dot(input);
-        assert_eq!(res, Error(Position(ErrorCode::Digit as u32, b".4435")));
+        assert_eq!(res, Error(Position(ErrorKind::Digit, &b".4435"[..])));
     }
 
     #[test]
@@ -1260,7 +1249,7 @@ mod test {
     fn flt_base_no_digits_before_dot() {
         let input = &b"0.0"[..];
         let res = flt_base_no_digits_bef_dot(input);
-        assert_eq!(res, Error(Position(ErrorCode::Tag as u32, b"0.0")));
+        assert_eq!(res, Error(Position(ErrorKind::Tag, &b"0.0"[..])));
     }
 
     #[test]
@@ -1274,7 +1263,7 @@ mod test {
     fn flt_base_no_digits_before_dot3() {
         let input = &b".\n"[..];
         let res = flt_base_no_digits_bef_dot(input);
-        assert_eq!(res, Error(Position(ErrorCode::Digit as u32, b"\n" /* dot is consumed */)));
+        assert_eq!(res, Error(Position(ErrorKind::Digit, &b"\n"[..] /* dot is consumed */)));
     }
 
     #[test]
@@ -1337,7 +1326,7 @@ mod test {
     fn flt_exponent_value() {
         let input = &b"eee"[..];
         let res = flt_exponent(input);
-        assert_eq!(res, Error(Position(ErrorCode::Digit as u32, b"ee" /* one e consumed */)));
+        assert_eq!(res, Error(Position(ErrorKind::Digit, &b"ee"[..] /* one e consumed */)));
     }
 
     #[test]
@@ -1638,7 +1627,7 @@ mod test {
     fn integer_scalar_value() {
         let input = &b"-------"[..];
         let res = int_scalar_value(input);
-        assert_eq!(res, Error(Position(ErrorCode::Alt as u32, b"-------")));
+        assert_eq!(res, Error(Position(ErrorKind::Alt, &b"-------"[..])));
     }
 
     #[test]
@@ -1935,14 +1924,14 @@ mod test {
     fn bad_array() {
         let input = &b"[true, \"a\", 14, 19, 5.0e1];\n"[..];
         let res = array(input);
-        assert_eq!(res, Error(Position(ErrorCode::Alt as u32, b"[true, \"a\", 14, 19, 5.0e1];\n")));
+        assert_eq!(res, Error(Position(ErrorKind::Alt, &b"[true, \"a\", 14, 19, 5.0e1];\n"[..])));
     }
 
     #[test]
     fn bad_array2() {
         let input = &b"[\"a bad array\", 12, 3.0e-1, true];\n"[..];
         let res = array(input);
-        assert_eq!(res, Error(Position(ErrorCode::Alt as u32, b"[\"a bad array\", 12, 3.0e-1, true];\n")));
+        assert_eq!(res, Error(Position(ErrorKind::Alt, &b"[\"a bad array\", 12, 3.0e-1, true];\n"[..])));
     }
 
     #[test]
@@ -2563,20 +2552,23 @@ mod test {
 
     #[test]
     fn conf_simple_bad_array() {
-        let parsed = conf(&b"bad_array = [\"a bad array\", 12, 3.0e-1, true];\n"[..]);
-        assert_eq!(parsed, Error(Code(0)));
+        let input = b"bad_array = [\"a bad array\", 12, 3.0e-1, true];\n";
+        let parsed = conf(&input[..]);
+        assert_eq!(parsed, Error(Position(ErrorKind::Eof, &input[..])));
     }
 
     #[test]
     fn conf_bad_array() {
-        let parsed = conf(&b"bad_array = [\"a bad array\", (\"array\", 5, 4, 2)];\n"[..]);
-        assert_eq!(parsed, Error(Code(0)));
+        let input = b"bad_array = [\"a bad array\", (\"array\", 5, 4, 2)];\n";
+        let parsed = conf(&input[..]);
+        assert_eq!(parsed, Error(Position(ErrorKind::Eof, &input[..])));
     }
 
     #[test]
     fn conf_bad_array_not_scalar() {
-        let parsed = conf(&b"bad_array = [(1, 2, 3), (4, 5, 6)];\n"[..]);
-        assert_eq!(parsed, Error(Code(0)));
+        let input = b"bad_array = [(1, 2, 3), (4, 5, 6)];\n";
+        let parsed = conf(&input[..]);
+        assert_eq!(parsed, Error(Position(ErrorKind::Eof, &input[..])));
     }
 
     #[test]


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to test and upgrade (if needed) your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!
- [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
- [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
- [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!
