### PR TITLE
Update dependency: nom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/filipegoncalves/rust-config"
 readme = "README.md"
 
 [dependencies]
-nom = "~1.0.0"
+nom = "~1"


### PR DESCRIPTION
Update the "nom" dependency.

Build and `cargo test`ed with nom `1.2.1` successfully.
